### PR TITLE
Add support for using addresses that may not exist on all objects in the tree.

### DIFF
--- a/src/angular-ui-tree-filter.js
+++ b/src/angular-ui-tree-filter.js
@@ -56,6 +56,11 @@
              */
             function resolveAddress(object, path) {
                 const parts = path.split('.');
+
+                if (object === undefined) {
+                    return;
+                }
+
                 return parts.length < 2 ? object[parts[0]] : resolveAddress(object[parts[0]], parts.slice(1).join('.'));
             }
 

--- a/test/unit/spec/angular-ui-tree-filter.spec.js
+++ b/test/unit/spec/angular-ui-tree-filter.spec.js
@@ -154,6 +154,8 @@ describe('Module: ui.tree-filter', function () {
             uiTreeFilterSettings.addresses.push('nonexistent.property');
         });
 
-        expect(uiTreeFilter(sampleTree[0], matchedString)).not.toThrow;
-	});
+        expect(function () {
+            uiTreeFilter(sampleTree[0], matchedString)
+        }).not.toThrow();
+    });
 });

--- a/test/unit/spec/angular-ui-tree-filter.spec.js
+++ b/test/unit/spec/angular-ui-tree-filter.spec.js
@@ -147,4 +147,13 @@ describe('Module: ui.tree-filter', function () {
         expect(uiTreeFilter(sampleTree[0], matchedString, ['title', 'description', 'nested.property'])).toBe(true);
     });
 
+    it('should support objects that may not have all addresses', function () {
+        const matchedString = 'nested';
+
+        inject(function (uiTreeFilterSettings) {
+            uiTreeFilterSettings.addresses.push('nonexistent.property');
+        });
+
+        expect(uiTreeFilter(sampleTree[0], matchedString)).not.toThrow;
+	});
 });

--- a/test/unit/spec/angular-ui-tree-filter.spec.js
+++ b/test/unit/spec/angular-ui-tree-filter.spec.js
@@ -155,7 +155,7 @@ describe('Module: ui.tree-filter', function () {
         });
 
         expect(function () {
-            uiTreeFilter(sampleTree[0], matchedString)
+            uiTreeFilter(sampleTree[0], matchedString);
         }).not.toThrow();
     });
 });


### PR DESCRIPTION
While working on a project that has tree nodes with different locations of the 'name' property that we want to search on, we ran into this issue.