### PR TITLE
improved pattern null check

### DIFF
--- a/src/angular-ui-tree-filter.js
+++ b/src/angular-ui-tree-filter.js
@@ -96,7 +96,7 @@
              */
             return function (item, pattern, addresses) {
                 addresses = addresses || uiTreeFilterSettings.addresses;
-                return pattern === undefined || addresses.reduce(function (foundSoFar, fieldName) {
+                return !pattern || addresses.reduce(function (foundSoFar, fieldName) {
                     return foundSoFar || testForField(item, pattern, fieldName);
                 }, false);
             };


### PR DESCRIPTION
modified short circuit on 'pattern' parameter to use a truthy check
rather than explicitly checking against undefined. This will stop the
filter from processing when the pattern is null or empty in addition to
undefined.